### PR TITLE
Revert "Use bundler 2.2.32 in rc-docs image"

### DIFF
--- a/rc-docs/Dockerfile
+++ b/rc-docs/Dockerfile
@@ -19,7 +19,6 @@ RUN set -ex \
 RUN set -ex \
     && wget https://raw.githubusercontent.com/cloudfoundry/cloud_controller_ng/main/docs/v3/Gemfile.lock \
     && wget https://raw.githubusercontent.com/cloudfoundry/cloud_controller_ng/main/docs/v3/Gemfile \
-    && gem install bundler:2.2.32 \
     && bundle install \
     && rm Gemfile \
     && rm Gemfile.lock \


### PR DESCRIPTION
Reverts cloudfoundry/capi-dockerfiles#21