### PR TITLE
Bump to cf cli 8 for sits tests

### DIFF
--- a/sits/Dockerfile
+++ b/sits/Dockerfile
@@ -53,9 +53,9 @@ RUN \
   chmod +x /usr/bin/bosh
 
 # Install the cf CLI
-RUN \
-  wget -q -O cf.deb "https://cli.run.pivotal.io/stable?release=debian64&source=github-rel" && \
-  dpkg -i cf.deb
+RUN wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | apt-key add - && \
+    echo "deb https://packages.cloudfoundry.org/debian stable main" | tee /etc/apt/sources.list.d/cloudfoundry-cli.list && \
+    apt-get update && apt-get -y install cf8-cli
 
 # credhub-cli
 RUN \


### PR DESCRIPTION
While trying to figure out elsa's super flaky-ness, saw we were still using cf cli 6 in tests.  Which we definitely shouldn't be.

Correspond sync integration test pr that needs to be merged along with this is - https://github.com/cloudfoundry/sync-integration-tests/pull/22