### PR TITLE
Bump images to ruby 3.2

### DIFF
--- a/capi-migration-compatibility/Dockerfile
+++ b/capi-migration-compatibility/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1-buster
+FROM ruby:3.2-buster
 
 ENV bosh_cli_version 7.2.2
 ENV bbl_version 7.2.12

--- a/capi-ruby-units/Dockerfile
+++ b/capi-ruby-units/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1-buster
+FROM ruby:3.2-buster
 MAINTAINER https://github.com/cloudfoundry/capi-dockerfiles
 
 RUN set -ex \

--- a/capi-runtime-ci/Dockerfile
+++ b/capi-runtime-ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1-buster
+FROM ruby:3.2-buster
 
 ENV bosh_cli_version 7.2.2
 


### PR DESCRIPTION
needed for https://github.com/cloudfoundry/cloud_controller_ng/pull/3219 and https://github.com/cloudfoundry/capi-release/pull/302 bumps to ruby 3.2