### PR TITLE
bump to go 1.21.3

### DIFF
--- a/capi-ruby-units/Dockerfile
+++ b/capi-ruby-units/Dockerfile
@@ -24,8 +24,8 @@ RUN set -ex \
 ENV GOPATH $HOME/go
 ENV PATH $HOME/go/bin:/usr/local/go/bin:$PATH
 RUN \
-  wget https://storage.googleapis.com/golang/go1.18.5.linux-amd64.tar.gz -P /tmp && \
-  tar xzvf /tmp/go1.18.5.linux-amd64.tar.gz -C /usr/local && \
+  wget https://storage.googleapis.com/golang/go1.21.3.linux-amd64.tar.gz -P /tmp && \
+  tar xzvf /tmp/go1.21.3.linux-amd64.tar.gz -C /usr/local && \
   mkdir $GOPATH && \
   rm -rf /tmp/*
 


### PR DESCRIPTION
- might try to stay on a support go version