### PR TITLE
Switch from s3.amazonaws to storage.googleapis for bosh cli downloads

### DIFF
--- a/bosh-lite/Dockerfile
+++ b/bosh-lite/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && \
     bsdmainutils
 
 
-RUN wget -O /usr/local/bin/bosh https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-${bosh_cli_version}-linux-amd64
+RUN wget -O /usr/local/bin/bosh https://storage.googleapis.com/bosh-cli-artifacts/bosh-cli-${bosh_cli_version}-linux-amd64
 RUN chmod +x /usr/local/bin/bosh
 
 # Every once in a while, you'll see "Updates are available for some Cloud SDK components."

--- a/capi-migration-compatibility/Dockerfile
+++ b/capi-migration-compatibility/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN \
-  wget https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-${bosh_cli_version}-linux-amd64 --output-document="/usr/bin/bosh" && \
+  wget https://storage.googleapis.com/bosh-cli-artifacts/bosh-cli-${bosh_cli_version}-linux-amd64 --output-document="/usr/bin/bosh" && \
   chmod +x /usr/bin/bosh
 
 # Install bbl

--- a/capi-runtime-ci/Dockerfile
+++ b/capi-runtime-ci/Dockerfile
@@ -28,5 +28,5 @@ RUN \
     zip \
     zlib1g-dev
 
-RUN wget -O /usr/local/bin/bosh https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-${bosh_cli_version}-linux-amd64
+RUN wget -O /usr/local/bin/bosh https://storage.googleapis.com/bosh-cli-artifacts/bosh-cli-${bosh_cli_version}-linux-amd64
 RUN chmod +x /usr/local/bin/bosh

--- a/sits/Dockerfile
+++ b/sits/Dockerfile
@@ -49,7 +49,7 @@ RUN \
 
 # Install the golang bosh CLI
 RUN \
-  wget https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-${bosh_cli_version}-linux-amd64 --output-document="/usr/bin/bosh" && \
+  wget https://storage.googleapis.com/bosh-cli-artifacts/bosh-cli-${bosh_cli_version}-linux-amd64 --output-document="/usr/bin/bosh" && \
   chmod +x /usr/bin/bosh
 
 # Install the cf CLI


### PR DESCRIPTION
- seems bosh team switch where they are storing new versions of the bosh cli (https://github.com/cloudfoundry/homebrew-tap/pull/90)

this will fix the red pipeline jobs on https://ci.capi.land/teams/main/pipelines/docker-images