### PR TITLE
Use bookworm instead of buster

### DIFF
--- a/bosh-lite/Dockerfile
+++ b/bosh-lite/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:latest
 LABEL org.opencontainers.image.authors="CF CAPI team"
 LABEL org.opencontainers.image.url="https://github.com/cloudfoundry/capi-dockerfiles"
 
-ENV bosh_cli_version 7.7.2
+ENV bosh_cli_version=7.7.2
 
 RUN apt-get update && \
     apt-get -y install \

--- a/capi-ruby-units/Dockerfile
+++ b/capi-ruby-units/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.2-buster
+FROM ruby:3.2-bookworm
 LABEL org.opencontainers.image.authors="CF CAPI team"
 LABEL org.opencontainers.image.url="https://github.com/cloudfoundry/capi-dockerfiles"
 
@@ -17,7 +17,8 @@ RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg m
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN service mysql restart && \
+RUN ln -s /etc/init.d/mariadb /etc/init.d/mysql && \
+    service mysql restart && \
     sed -i 's/peer$/trust/;s/scram-sha-256/trust/' /etc/postgresql/16/main/pg_hba.conf && \
     service postgresql restart
 

--- a/capi-runtime-ci/Dockerfile
+++ b/capi-runtime-ci/Dockerfile
@@ -1,8 +1,8 @@
-FROM ruby:3.2-buster
+FROM ruby:3.2-bookworm
 LABEL org.opencontainers.image.authors="CF CAPI team"
 LABEL org.opencontainers.image.url="https://github.com/cloudfoundry/capi-dockerfiles"
 
-ENV bosh_cli_version 7.7.2
+ENV bosh_cli_version=7.7.2
 
 RUN apt-get update && \
     apt-get clean && \

--- a/rc-docs/Dockerfile
+++ b/rc-docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.2-buster
+FROM ruby:3.2-bookworm
 LABEL org.opencontainers.image.authors="CF CAPI team"
 LABEL org.opencontainers.image.url="https://github.com/cloudfoundry/capi-dockerfiles"
 


### PR DESCRIPTION
As buster reached eol, switch to bookworm. To be able to continue using 'service mysql', an alias (link) is needed.