### PR TITLE
Add protoc to runtime-ci image

### DIFF
--- a/capi-runtime-ci/Dockerfile
+++ b/capi-runtime-ci/Dockerfile
@@ -10,3 +10,7 @@ RUN apt-get update && \
 
 RUN wget -q -O /usr/local/bin/bosh https://storage.googleapis.com/bosh-cli-artifacts/bosh-cli-${bosh_cli_version}-linux-amd64 && \
     chmod +x /usr/local/bin/bosh
+
+RUN wget -q -O /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v3.6.1/protoc-3.6.1-linux-x86_64.zip && \
+    unzip -q /tmp/protoc.zip -d /usr/local && \
+    rm /tmp/protoc.zip


### PR DESCRIPTION
Protoc v3.6.1 is used to generate Ruby stubs for BBS models.