### PR TITLE
Add lsof needed by some tests

### DIFF
--- a/capi-ruby-units/Dockerfile
+++ b/capi-ruby-units/Dockerfile
@@ -5,6 +5,7 @@ LABEL org.opencontainers.image.url="https://github.com/cloudfoundry/capi-dockerf
 RUN apt-get update && \
     apt-get -y install \
       lsb-release \
+      lsof \
       zip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
This tool was previously installed as a transient dependency of default-mysql-server.